### PR TITLE
enables multi-platform images in publish action

### DIFF
--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -19,11 +19,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Publish Spiffworkflow-Connector
         uses: docker/build-push-action@v6
         with:
           file: ./Dockerfile
           push: true
           tags: ghcr.io/gsa-tts/spiffworkflow-connector:latest
+          platforms: linux/amd64, linux/arm64
 
 


### PR DESCRIPTION
This should fix issues with running emulation on our Macs. I have no issues running spiff with a locally built image, just the one pulled down from GHCR. This removes one more thing off the list of reasons it could be failing for me.

<img width="566" height="198" alt="image" src="https://github.com/user-attachments/assets/879a12b2-dfa1-43c4-a697-c00ce5afe6a7" />
