### PR TITLE
Update Docker base image to python:3.13.13-slim-trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13.13-slim-trixie
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.21 /uv /uvx /bin/
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13.13-slim-trixie
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.21 /uv /uvx /bin/
 


### PR DESCRIPTION
## Summary

Update the base image in both `Dockerfile` and `dev.Dockerfile` from `python:3.12-slim-bookworm` to `python:3.13.13-slim-trixie` to address Snyk vulnerability findings.

## Motivation

Snyk scans identified **84 vulnerabilities** in the current `python:3.12-slim-bookworm` base image, including **3 critical** and **3 high** severity issues. The `python:3.13.13-slim-trixie` image eliminates all critical and high severity vulnerabilities and aligns with the base image used in our production `spiff-arena` repository.

## Changes

- `Dockerfile`: `python:3.12-slim-bookworm` → `python:3.13.13-slim-trixie`
- `dev.Dockerfile`: `python:3.12-slim-bookworm` → `python:3.13.13-slim-trixie`

## Testing

All 8 existing tests pass with the updated base image.