### PR TITLE
Pic team 387 improvements

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -298,7 +298,7 @@ class v1_do_artifacts_connector:
         attachments = template_data.get("attachments", [])
 
         # A hack until we have rich text capabilities
-        if ("\n" in template_data["locationOfProposedAction"]):
+        if "\n" in template_data["locationOfProposedAction"]:
             template_data["locationOfProposedActionMultiline"] = True
 
         # This is a total hack. The issue is that the user can enter any string,

--- a/artifacts.py
+++ b/artifacts.py
@@ -303,7 +303,7 @@ class v1_do_artifacts_connector:
 
         # This is a total hack. The issue is that the user can enter any string,
         # so we are trying to format an arbitrary string.
-        template_data["exclusions"] = "INSANE!"
+        template_data["exclusions"] = template_data["exclusionsText"].split("\n")
         template_data["lupDecisions"] = template_data["lupDecisions"].split("\n")
 
         template_data["responsibleOfficial"] = template_data["responsibleOfficial"]

--- a/artifacts.py
+++ b/artifacts.py
@@ -298,7 +298,7 @@ class v1_do_artifacts_connector:
         attachments = template_data.get("attachments", [])
 
         # A hack until we have rich text capabilities
-        if "\n" in template_data["locationOfProposedAction"]:
+        if "\n" in template_data.get("locationOfProposedAction", ""):
             template_data["locationOfProposedActionMultiline"] = True
 
         # This is a total hack. The issue is that the user can enter any string,

--- a/artifacts.py
+++ b/artifacts.py
@@ -297,9 +297,13 @@ class v1_do_artifacts_connector:
 
         attachments = template_data.get("attachments", [])
 
+        # A hack until we have rich text capabilities
+        if ("\n" in template_data["locationOfProposedAction"]):
+            template_data["locationOfProposedActionMultiline"] = True
+
         # This is a total hack. The issue is that the user can enter any string,
         # so we are trying to format an arbitrary string.
-        template_data["exclusions"] = template_data["exclusionsText"].split("\n")
+        template_data["exclusions"] = "INSANE!"
         template_data["lupDecisions"] = template_data["lupDecisions"].split("\n")
 
         template_data["responsibleOfficial"] = template_data["responsibleOfficial"]

--- a/artifacts.py
+++ b/artifacts.py
@@ -297,8 +297,10 @@ class v1_do_artifacts_connector:
 
         attachments = template_data.get("attachments", [])
 
+        projectLocation = template_data.get("projectLocation", "") or template_data.get("locationOfProposedAction", "")
+
         # A hack until we have rich text capabilities
-        if "\n" in template_data.get("locationOfProposedAction", ""):
+        if "\n" in projectLocation:
             template_data["locationOfProposedActionMultiline"] = True
 
         # This is a total hack. The issue is that the user can enter any string,

--- a/artifacts.py
+++ b/artifacts.py
@@ -298,10 +298,12 @@ class v1_do_artifacts_connector:
         attachments = template_data.get("attachments", [])
 
         projectLocation = template_data.get("projectLocation", "") or template_data.get("locationOfProposedAction", "")
+        template_data["projectLocation"] = projectLocation
 
         # A hack until we have rich text capabilities
         if "\n" in projectLocation:
             template_data["locationOfProposedActionMultiline"] = True
+
 
         # This is a total hack. The issue is that the user can enter any string,
         # so we are trying to format an arbitrary string.

--- a/artifacts.py
+++ b/artifacts.py
@@ -304,7 +304,6 @@ class v1_do_artifacts_connector:
         if "\n" in projectLocation:
             template_data["locationOfProposedActionMultiline"] = True
 
-
         # This is a total hack. The issue is that the user can enter any string,
         # so we are trying to format an arbitrary string.
         template_data["exclusions"] = template_data["exclusionsText"].split("\n")

--- a/main.py
+++ b/main.py
@@ -191,7 +191,7 @@ class DirectArtifactPost:
         bucket = get_bucket_for_storage(storage)
 
         try:
-            s3_client.put_object(Bucket=bucket, Key=artifact_id, Body=pdf_stream)
+            s3_client.put_object(Bucket=bucket, Key=artifact_id, Body=pdf_stream, ContentType="application/pdf",)
         except Exception as e:
             logger.exception("Error uploading artifact to S3")
             resp.status = falcon.HTTP_500

--- a/main.py
+++ b/main.py
@@ -191,7 +191,12 @@ class DirectArtifactPost:
         bucket = get_bucket_for_storage(storage)
 
         try:
-            s3_client.put_object(Bucket=bucket, Key=artifact_id, Body=pdf_stream, ContentType="application/pdf",)
+            s3_client.put_object(
+                Bucket=bucket,
+                Key=artifact_id,
+                Body=pdf_stream,
+                ContentType="application/pdf",
+            )
         except Exception as e:
             logger.exception("Error uploading artifact to S3")
             resp.status = falcon.HTTP_500

--- a/templates/blm-ce.html
+++ b/templates/blm-ce.html
@@ -8,30 +8,32 @@
   <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="container mx-auto p-5">
-      <header role="banner" class="flex">
-        <div class="w-15 flex-none">{% include "blm_logo.svg" %}</div>
-        <div class="flex-1 ml-3">
-          <p class="agency__name uppercase">
-            United States Department of the Interior
-          </p>
-          <p class="agency__sub-name">Bureau of Land Management</p>
-        </div>
-      </header>
-      <section class="flex mt-2" aria-label="Document Information">
-        <address class="flex-1">
-          <ul class="list-none">
-            <li>{{fieldofficeName}}</li>
-            <li>{{streetAddress}}</li>
-            <li>{{city}}, {{zipCode}}</li>
-          </ul>
-        </address>
-        <div class="flex-1">
-          <ul class="list-none float-right">
-            <li>Categorical Exclusion</li>
-            <li>{{categoricalExclusionID}}</li>
-          </ul>
-        </div>
-      </section>
+      <div class="place-items-center">
+        <header role="banner" class="flex">
+          <div class="w-15 flex-none">{% include "blm_logo.svg" %}</div>
+          <div class="flex-1 ml-3">
+            <p class="agency__name uppercase">
+              United States Department of the Interior
+            </p>
+            <p class="agency__sub-name">Bureau of Land Management</p>
+          </div>
+        </header>
+        <section class="flex mt-2" aria-label="Document Information">
+          <address class="flex-1">
+            <ul class="list-none">
+              <li>{{fieldofficeName}}</li>
+              <li>{{streetAddress}}</li>
+              <li>{{city}}, {{zipCode}}</li>
+            </ul>
+          </address>
+          <div class="flex-1">
+            <ul class="list-none float-right">
+              <li>Categorical Exclusion</li>
+              <li>{{categoricalExclusionID}}</li>
+            </ul>
+          </div>
+        </section>
+      </div>
       <main role="main" id="main-content">
         <h1 class="sr-only">{{projectTitle}}</h1>
         <ol class="list-upper-alpha mt-5">
@@ -76,80 +78,101 @@
             <p>The proposed action will not:</p>
             <ol>
               <li>
-                <h4>Have significant impacts on public health or safety.</h4>
-                <p><strong>Rationale:</strong> {{publicHealthImpacts}}</p>
+                <h4>
+                  <strong
+                    >Have significant impacts on public health or
+                    safety.</strong
+                  >
+                </h4>
+                <p>Rationale:{{publicHealthImpacts}}</p>
               </li>
               <li>
                 <h4>
-                  Have significant impacts on such natural resources and unique
-                  geographic characteristics as historic or cultural resources;
-                  park, recreation or refuge lands; wilderness areas; wild or
-                  scenic rivers; national natural landmarks; sole or principal
-                  drinking water aquifers; prime farmlands; wetlands;
-                  floodplains; national monuments; migratory birds; and other
-                  ecologically significant or critical areas.
+                  <strong>
+                    Have significant impacts on such natural resources and
+                    unique geographic characteristics as historic or cultural
+                    resources; park, recreation or refuge lands; wilderness
+                    areas; wild or scenic rivers; national natural landmarks;
+                    sole or principal drinking water aquifers; prime farmlands;
+                    wetlands; floodplains; national monuments; migratory birds;
+                    and other ecologically significant or critical areas.
+                  </strong>
                 </h4>
-                <p><strong>Rationale:</strong> {{naturalResourcesImpacts}}</p>
+                <p>Rationale: {{naturalResourcesImpacts}}</p>
               </li>
               <li>
                 <h4>
-                  Have highly uncertain and potentially significant
-                  environmental effects or involve unique or unknown
-                  environmental risks.
+                  <strong>
+                    Have highly uncertain and potentially significant
+                    environmental effects or involve unique or unknown
+                    environmental risks.
+                  </strong>
                 </h4>
-                <p><strong>Rationale</strong> {{controversialEffects}}</p>
+                <p>Rationale: {{controversialEffects}}</p>
               </li>
               <li>
                 <h4>
-                  Establish a precedent for future action or represent a
-                  decision in principle about future actions with potentially
-                  significant environmental effects.
+                  <strong>
+                    Establish a precedent for future action or represent a
+                    decision in principle about future actions with potentially
+                    significant environmental effects.
+                  </strong>
                 </h4>
-                <p><strong>Rationale:</strong> {{precedentForFutureAction}}</p>
+                <p>Rationale: {{precedentForFutureAction}}</p>
               </li>
               <li>
                 <h4>
-                  Have a direct relationship to other actions that implicate
-                  potentially significant environmental effects.
+                  <strong>
+                    Have a direct relationship to other actions that implicate
+                    potentially significant environmental effects.
+                  </strong>
                 </h4>
-                <p><strong>Rationale:</strong> {{cumulativeImpacts}}</p>
+                <p>Rationale: {{cumulativeImpacts}}</p>
               </li>
               <li>
                 <h4>
-                  Have significant impacts on properties listed, or eligible for
-                  listing, on the National Register of Historic Places as
-                  determined by the bureau.
+                  <strong>
+                    Have significant impacts on properties listed, or eligible
+                    for listing, on the National Register of Historic Places as
+                    determined by the bureau.
+                  </strong>
                 </h4>
-                <p><strong>Rationale:</strong> {{historicProperties}}</p>
+                <p>Rationale: {{historicProperties}}</p>
               </li>
               <li>
                 <h4>
-                  Have significant impacts on species listed, or proposed to be
-                  listed, on the List of Endangered or Threatened Species, or
-                  have significant impacts on designated Critical Habitat for
-                  these species.
+                  <strong>
+                    Have significant impacts on species listed, or proposed to
+                    be listed, on the List of Endangered or Threatened Species,
+                    or have significant impacts on designated Critical Habitat
+                    for these species.
+                  </strong>
                 </h4>
-                <p><strong>Rationale:</strong> {{endangeredSpeciesImpacts}}</p>
+                <p>Rationale: {{endangeredSpeciesImpacts}}</p>
               </li>
               <li>
                 <h4>
-                  Significantly limit access to and ceremonial use of Indian
-                  sacred sites on Federal lands by Indian religious
-                  practitioners or significantly adversely affect the physical
-                  integrity of such sacred sites.
+                  <strong>
+                    Significantly limit access to and ceremonial use of Indian
+                    sacred sites on Federal lands by Indian religious
+                    practitioners or significantly adversely affect the physical
+                    integrity of such sacred sites.
+                  </strong>
                 </h4>
-                <p><strong>Rationale:</strong> {{limitAccessToSacredSites}}</p>
+                <p>Rationale: {{limitAccessToSacredSites}}</p>
               </li>
               <li>
                 <h4>
-                  Contribute to potentially significant effects resulting from
-                  the introduction, continued existence, or spread of noxious
-                  weeds or non-native invasive species known to occur in the
-                  area or from other actions that promote the introduction,
-                  growth, or expansion of the range of such species (Federal
-                  Noxious Weed Control Act).
+                  <strong>
+                    Contribute to potentially significant effects resulting from
+                    the introduction, continued existence, or spread of noxious
+                    weeds or non-native invasive species known to occur in the
+                    area or from other actions that promote the introduction,
+                    growth, or expansion of the range of such species (Federal
+                    Noxious Weed Control Act).
+                  </strong>
                 </h4>
-                <p><strong>Rationale:</strong> {{promoteNoxiousWeeds}}</p>
+                <p>Rationale: {{promoteNoxiousWeeds}}</p>
               </li>
             </ol>
           </li>

--- a/templates/blm-ce.html
+++ b/templates/blm-ce.html
@@ -1,227 +1,228 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <title>{{projectTitle}}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    {% include "base-styles.html" %} {% include "tailwind.html" %}
-  </head>
-  <body>
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-    <div class="container mx-auto p-5">
-      <div class="place-items-center">
-        <header role="banner" class="flex">
-          <div class="w-15 flex-none">{% include "blm_logo.svg" %}</div>
-          <div class="flex-1 ml-3">
-            <p class="agency__name uppercase">
-              United States Department of the Interior
-            </p>
-            <p class="agency__sub-name">Bureau of Land Management</p>
-          </div>
-        </header>
-        <section class="flex mt-2" aria-label="Document Information">
-          <address class="flex-1">
-            <ul class="list-none">
-              <li>{{fieldofficeName}}</li>
-              <li>{{streetAddress}}</li>
-              <li>{{city}}, {{zipCode}}</li>
-            </ul>
-          </address>
-          <div class="flex-1">
-            <ul class="list-none float-right">
-              <li>Categorical Exclusion</li>
-              <li>{{categoricalExclusionID}}</li>
-            </ul>
-          </div>
-        </section>
-      </div>
-      <main role="main" id="main-content">
-        <h1 class="sr-only">{{projectTitle}}</h1>
-        <ol class="list-upper-alpha mt-5">
-          <li>
-            <h3>Background:</h3>
-            <p>
-              Proposed Action Title/Type: {{projectTitle}}
-              <br />Location of Proposed Action: {{locationOfProposedAction}}
-              <br />Lease/Serial/Case File No (if any):
-              {{leaseSerialCaseFileNumber}} <br />Applicant: {{applicant}}
-            </p>
-          </li>
-          <li>
-            <h3>Description of Proposed Action:</h3>
-            <p>{{projectDescription}}</p>
-          </li>
-          <li>
-            <h3>Land Use Plan Conformance:</h3>
-            <p>
-              Land Use Plan Name: {{ landUsePlanName }}<br />
-              Date Approved: {{ dateApproved }}<br />
-              The proposed action is in conformance with the applicable LUP
-              because...
-            </p>
-            {% for decision in lupDecisions %}
-            <p style="margin-top: 0.5em">{{ decision }}</p>
-            {% endfor %}
-          </li>
-          <li>
-            <h3>Compliance with NEPA:</h3>
-            <p>
-              The Proposed Action is categorically excluded from further
-              documentation under the National Environmental Policy Act (NEPA)
-              in accordance with:
-            </p>
-            {% for exclusion in exclusions %}
-            <p style="margin-top: 0.5em">{{ exclusion }}</p>
-            {% endfor %}
-          </li>
-          <li>
-            <h3>Extraordinary Circumstances Review:</h3>
-            <p>The proposed action will not:</p>
-            <ol>
-              <li>
-                <h4>
-                  <strong
-                    >Have significant impacts on public health or
-                    safety.</strong
-                  >
-                </h4>
-                <p>Rationale:{{publicHealthImpacts}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Have significant impacts on such natural resources and
-                    unique geographic characteristics as historic or cultural
-                    resources; park, recreation or refuge lands; wilderness
-                    areas; wild or scenic rivers; national natural landmarks;
-                    sole or principal drinking water aquifers; prime farmlands;
-                    wetlands; floodplains; national monuments; migratory birds;
-                    and other ecologically significant or critical areas.
-                  </strong>
-                </h4>
-                <p>Rationale: {{naturalResourcesImpacts}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Have highly uncertain and potentially significant
-                    environmental effects or involve unique or unknown
-                    environmental risks.
-                  </strong>
-                </h4>
-                <p>Rationale: {{controversialEffects}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Establish a precedent for future action or represent a
-                    decision in principle about future actions with potentially
-                    significant environmental effects.
-                  </strong>
-                </h4>
-                <p>Rationale: {{precedentForFutureAction}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Have a direct relationship to other actions that implicate
-                    potentially significant environmental effects.
-                  </strong>
-                </h4>
-                <p>Rationale: {{cumulativeImpacts}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Have significant impacts on properties listed, or eligible
-                    for listing, on the National Register of Historic Places as
-                    determined by the bureau.
-                  </strong>
-                </h4>
-                <p>Rationale: {{historicProperties}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Have significant impacts on species listed, or proposed to
-                    be listed, on the List of Endangered or Threatened Species,
-                    or have significant impacts on designated Critical Habitat
-                    for these species.
-                  </strong>
-                </h4>
-                <p>Rationale: {{endangeredSpeciesImpacts}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Significantly limit access to and ceremonial use of Indian
-                    sacred sites on Federal lands by Indian religious
-                    practitioners or significantly adversely affect the physical
-                    integrity of such sacred sites.
-                  </strong>
-                </h4>
-                <p>Rationale: {{limitAccessToSacredSites}}</p>
-              </li>
-              <li>
-                <h4>
-                  <strong>
-                    Contribute to potentially significant effects resulting from
-                    the introduction, continued existence, or spread of noxious
-                    weeds or non-native invasive species known to occur in the
-                    area or from other actions that promote the introduction,
-                    growth, or expansion of the range of such species (Federal
-                    Noxious Weed Control Act).
-                  </strong>
-                </h4>
-                <p>Rationale: {{promoteNoxiousWeeds}}</p>
-              </li>
-            </ol>
-          </li>
-          <li>
-            <h3>Conclusion</h3>
-            <p>
-              This categorical exclusion is appropriate in this situation
-              because there are no extraordinary circumstances having effects
-              that significantly affect the environment. The proposed action has
-              been reviewed, and none of the extraordinary circumstances
-              described in 43 CFR Part 46.215 apply. I considered
-              {{categoricalExclusionJustification}}
-            </p>
-          </li>
-          <li>
-            <h3>Signature</h3>
-            <div aria-label="Signature area">________________________</div>
-          </li>
-        </ol>
-      </main>
-      <footer role="contentinfo">
-        <section class="mt-3">
-          <p>
-            <strong>Responsible Official:</strong> {{responsibleOfficial}}
-            <strong>Date:</strong> {{approvalDate}}
+
+<head>
+  <title>{{projectTitle}}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  {% include "base-styles.html" %} {% include "tailwind.html" %}
+</head>
+
+<body>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+  <div class="container mx-auto p-5">
+    <div class="place-items-center">
+      <header role="banner" class="flex">
+        <div class="w-15 flex-none">{% include "blm_logo.svg" %}</div>
+        <div class="flex-1 ml-3">
+          <p class="agency__name uppercase">
+            United States Department of the Interior
           </p>
-        </section>
-        <section class="mt-3">
-          <h3 class="font-bold">Contact Person</h3>
-          <p>
-            For additional information concerning this CX review, please
-            contact:
-          </p>
-          <address>
-            {{contactPerson}}, {{contactTitle}}<br />
-            {{officeName}} {{mailingAddress}} {{telephoneNumber}}
-          </address>
-        </section>
-        {% if numberOfAttachments > 0 %}
-        <section class="mt-3">
-          <h3 class="font-bold">ATTACHMENTS:</h3>
-          <p>
-            {% if numberOfAttachments == 1 %} {{ numberOfAttachments }}
-            attachment is attached below. {% else %} {{ numberOfAttachments }}
-            attachments are attached below. {% endif %}
-          </p>
-        </section>
-        {% endif %}
-      </footer>
+          <p class="agency__sub-name">Bureau of Land Management</p>
+        </div>
+      </header>
+      <section class="flex mt-2" aria-label="Document Information">
+        <address class="flex-1">
+          <ul class="list-none">
+            <li>{{fieldofficeName}}</li>
+            <li>{{streetAddress}}</li>
+            <li>{{city}}, {{zipCode}}</li>
+          </ul>
+        </address>
+        <div class="flex-1">
+          <ul class="list-none float-right">
+            <li>Categorical Exclusion</li>
+            <li>{{categoricalExclusionID}}</li>
+          </ul>
+        </div>
+      </section>
     </div>
-  </body>
+    <main role="main" id="main-content">
+      <h1 class="sr-only">{{projectTitle}}</h1>
+      <ol class="list-upper-alpha mt-5">
+        <li>
+          <h3>Background:</h3>
+          <p>Proposed Action Title/Type: {{projectTitle}}</p>
+          <p>
+            Location of Proposed Action: {% if locationOfProposedActionMultiline %}<div style="margin-left: 1em; white-space: pre-line">{{ locationOfProposedAction }}</div>{% else %}{{ locationOfProposedAction }}{% endif %}
+          </p>
+          <p>Lease/Serial/Case File No (if any): {{leaseSerialCaseFileNumber}}</p>
+          <p>Applicant: {{applicant}}</p>
+        </li>
+        <li>
+          <h3>Description of Proposed Action:</h3>
+          <p>{{projectDescription}}</p>
+        </li>
+        <li>
+          <h3>Land Use Plan Conformance:</h3>
+          <p>
+            Land Use Plan Name: {{ landUsePlanName }}<br />
+            Date Approved: {{ dateApproved }}<br />
+            The proposed action is in conformance with the applicable LUP
+            because...
+          </p>
+          {% for decision in lupDecisions %}
+          <p style="margin-top: 0.5em">{{ decision }}</p>
+          {% endfor %}
+        </li>
+        <li>
+          <h3>Compliance with NEPA:</h3>
+          <p>
+            The Proposed Action is categorically excluded from further
+            documentation under the National Environmental Policy Act (NEPA)
+            in accordance with:
+          </p>
+          {% for exclusion in exclusions %}
+          <p style="margin-top: 0.5em">{{ exclusion }}</p>
+          {% endfor %}
+        </li>
+        <li>
+          <h3>Extraordinary Circumstances Review:</h3>
+          <p>The proposed action will not:</p>
+          <ol>
+            <li>
+              <h4>
+                <strong>Have significant impacts on public health or
+                  safety.</strong>
+              </h4>
+              <p>Rationale:{{publicHealthImpacts}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Have significant impacts on such natural resources and
+                  unique geographic characteristics as historic or cultural
+                  resources; park, recreation or refuge lands; wilderness
+                  areas; wild or scenic rivers; national natural landmarks;
+                  sole or principal drinking water aquifers; prime farmlands;
+                  wetlands; floodplains; national monuments; migratory birds;
+                  and other ecologically significant or critical areas.
+                </strong>
+              </h4>
+              <p>Rationale: {{naturalResourcesImpacts}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Have highly uncertain and potentially significant
+                  environmental effects or involve unique or unknown
+                  environmental risks.
+                </strong>
+              </h4>
+              <p>Rationale: {{controversialEffects}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Establish a precedent for future action or represent a
+                  decision in principle about future actions with potentially
+                  significant environmental effects.
+                </strong>
+              </h4>
+              <p>Rationale: {{precedentForFutureAction}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Have a direct relationship to other actions that implicate
+                  potentially significant environmental effects.
+                </strong>
+              </h4>
+              <p>Rationale: {{cumulativeImpacts}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Have significant impacts on properties listed, or eligible
+                  for listing, on the National Register of Historic Places as
+                  determined by the bureau.
+                </strong>
+              </h4>
+              <p>Rationale: {{historicProperties}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Have significant impacts on species listed, or proposed to
+                  be listed, on the List of Endangered or Threatened Species,
+                  or have significant impacts on designated Critical Habitat
+                  for these species.
+                </strong>
+              </h4>
+              <p>Rationale: {{endangeredSpeciesImpacts}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Significantly limit access to and ceremonial use of Indian
+                  sacred sites on Federal lands by Indian religious
+                  practitioners or significantly adversely affect the physical
+                  integrity of such sacred sites.
+                </strong>
+              </h4>
+              <p>Rationale: {{limitAccessToSacredSites}}</p>
+            </li>
+            <li>
+              <h4>
+                <strong>
+                  Contribute to potentially significant effects resulting from
+                  the introduction, continued existence, or spread of noxious
+                  weeds or non-native invasive species known to occur in the
+                  area or from other actions that promote the introduction,
+                  growth, or expansion of the range of such species (Federal
+                  Noxious Weed Control Act).
+                </strong>
+              </h4>
+              <p>Rationale: {{promoteNoxiousWeeds}}</p>
+            </li>
+          </ol>
+        </li>
+        <li>
+          <h3>Conclusion</h3>
+          <p>
+            This categorical exclusion is appropriate in this situation
+            because there are no extraordinary circumstances having effects
+            that significantly affect the environment. The proposed action has
+            been reviewed, and none of the extraordinary circumstances
+            described in 43 CFR Part 46.215 apply. I considered
+            {{categoricalExclusionJustification}}
+          </p>
+        </li>
+        <li>
+          <h3>Signature</h3>
+          <div aria-label="Signature area">________________________</div>
+        </li>
+      </ol>
+    </main>
+    <footer role="contentinfo">
+      <section class="mt-3">
+        <p>
+          <strong>Responsible Official:</strong> {{responsibleOfficial}}
+          <strong>Date:</strong> {{approvalDate}}
+        </p>
+      </section>
+      <section class="mt-3">
+        <h3 class="font-bold">Contact Person</h3>
+        <p>
+          For additional information concerning this CX review, please
+          contact:
+        </p>
+        <address>
+          {{contactPerson}}, {{contactTitle}}<br />
+          {{officeName}} {{mailingAddress}} {{telephoneNumber}}
+        </address>
+      </section>
+      {% if numberOfAttachments > 0 %}
+      <section class="mt-3">
+        <h3 class="font-bold">ATTACHMENTS:</h3>
+        <p>
+          {% if numberOfAttachments == 1 %} {{ numberOfAttachments }}
+          attachment is attached below. {% else %} {{ numberOfAttachments }}
+          attachments are attached below. {% endif %}
+        </p>
+      </section>
+      {% endif %}
+    </footer>
+  </div>
+</body>
+
 </html>

--- a/templates/blm-ce.html
+++ b/templates/blm-ce.html
@@ -10,30 +10,18 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="container mx-auto p-5">
+    <div class="w-15 flex-none absolute top-5 left-5">{% include "blm_logo.svg" %}</div>
     <div class="place-items-center">
-      <header role="banner" class="flex">
-        <div class="w-15 flex-none">{% include "blm_logo.svg" %}</div>
-        <div class="flex-1 ml-3">
-          <p class="agency__name uppercase">
-            United States Department of the Interior
-          </p>
-          <p class="agency__sub-name">Bureau of Land Management</p>
-        </div>
-      </header>
-      <section class="flex mt-2" aria-label="Document Information">
-        <address class="flex-1">
-          <ul class="list-none">
-            <li>{{fieldofficeName}}</li>
-            <li>{{streetAddress}}</li>
-            <li>{{city}}, {{zipCode}}</li>
-          </ul>
-        </address>
-        <div class="flex-1">
-          <ul class="list-none float-right">
-            <li>Categorical Exclusion</li>
-            <li>{{categoricalExclusionID}}</li>
-          </ul>
-        </div>
+      <section class="flex mt-2 text-center" aria-label="Document Information">
+        <ul class="list-none">
+          <li class="uppercase font-bold">United States Department of the Interior</li>
+          <li class="font-bold">Bureau of Land Management</li>
+          <li>{{fieldOfficeName}}</li>  
+          <li>{{streetAddress}}</li>
+          <li>{{city}}, {{zipCode}}</li>
+          <li class="uppercase font-bold">Categorical Exclusion</li>
+          <li>{{categoricalExclusionID}}</li>
+        </ul>
       </section>
     </div>
     <main role="main" id="main-content">

--- a/templates/blm-ce.html
+++ b/templates/blm-ce.html
@@ -18,7 +18,7 @@
           <li class="font-bold">Bureau of Land Management</li>
           <li>{{fieldOfficeName}}</li>  
           <li>{{streetAddress}}</li>
-          <li>{{city}}, {{zipCode}}</li>
+          <li>{{city}}, {{state}} {{zipCode}}</li>
           <li class="uppercase font-bold">Categorical Exclusion</li>
           <li>{{categoricalExclusionID}}</li>
         </ul>

--- a/templates/blm-ce.html
+++ b/templates/blm-ce.html
@@ -31,7 +31,7 @@
           <h3>Background:</h3>
           <p>Proposed Action Title/Type: {{projectTitle}}</p>
           <p>
-            Location of Proposed Action: {% if locationOfProposedActionMultiline %}<div style="margin-left: 1em; white-space: pre-line">{{ locationOfProposedAction }}</div>{% else %}{{ locationOfProposedAction }}{% endif %}
+            Location of Proposed Action: {% if locationOfProposedActionMultiline %}<div style="margin-left: 1em; white-space: pre-line">{{ projectLocation }}</div>{% else %}{{ projectLocation }}{% endif %}
           </p>
           <p>Lease/Serial/Case File No (if any): {{leaseSerialCaseFileNumber}}</p>
           <p>Applicant: {{applicant}}</p>

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -129,7 +129,7 @@ class TestBLMSpecificFlows:
             "data": {
                 "projectTitle": "projectTitle_val",
                 "categoricalExclusionID": "categoricalExclusionID_val",
-                "fieldofficeName": "fieldofficeName_val",
+                "fieldOfficeName": "fieldOfficeName_val",
                 "streetAddress": "streetAddress_val",
                 "city": "city_val",
                 "zipCode": "zipCode_val",


### PR DESCRIPTION
**Addresses** parts of https://github.com/GSA-TTS/pic-team/issues/387.

- [x] Center the header on the document
- [x] Bold the questions under the extraordinary circumstances, and un-bold the rationale
- [x] Ensure location of proposed action retains the multi-line formatting in the final CE PDF
- [x] Fix a couple things that are broken, which highlights the fact that we need better validation
- [ ] Once merged, open a PR in pic-blm-cxworks to point to the new image

**Related to** https://github.com/GSA-TTS/pic-blm-cxworks/pull/1004, which addresses other parts.

**Example PDF**:  [pic-blm-387-example.pdf](https://github.com/user-attachments/files/28666974/pic-blm-387-example.pdf)

**Notes**: In a follow-up PR, I want to clean this code up. The interface is hidden in the template, we have mixed concerns (some blm stuff is hard-coded, some is parameterized), etc. However, my gut says that most of this stuff should live outside of the connector and with application code.

