### PR TITLE
Get v2 data and artifact template formats to match

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -300,7 +300,8 @@ class v1_do_artifacts_connector:
         # This is a total hack. The issue is that the user can enter any string,
         # so we are trying to format an arbitrary string.
         template_data["exclusions"] = template_data["exclusionsText"].split("\n")
-        template_data["lupDecisions"] = template_data["lupDecisions"].split("\n")
+        lupDecisions = template_data.get("landUsePlanDecisionText", "") or template_data.get("lupDecisions", "")
+        template_data["lupDecisions"] = lupDecisions.split("\n")
 
         template_data["responsibleOfficial"] = template_data["responsibleOfficial"]
         template_data["approvalDate"] = self._get_last_approval_date(template_data["approvers"])

--- a/artifacts.py
+++ b/artifacts.py
@@ -303,6 +303,8 @@ class v1_do_artifacts_connector:
         lupDecisions = template_data.get("landUsePlanDecisionText", "") or template_data.get("lupDecisions", "")
         template_data["lupDecisions"] = lupDecisions.split("\n")
 
+        template_data["landUsePlanDateApproved"] = template_data.get("dateApproved", "") or template_data.get("landUsePlanDateApproved", "")
+
         template_data["responsibleOfficial"] = template_data["responsibleOfficial"]
         template_data["approvalDate"] = self._get_last_approval_date(template_data["approvers"])
         # This assumes associated documents will be attachments

--- a/artifacts.py
+++ b/artifacts.py
@@ -303,7 +303,9 @@ class v1_do_artifacts_connector:
         lupDecisions = template_data.get("landUsePlanDecisionText", "") or template_data.get("lupDecisions", "")
         template_data["lupDecisions"] = lupDecisions.split("\n")
 
-        template_data["landUsePlanDateApproved"] = template_data.get("dateApproved", "") or template_data.get("landUsePlanDateApproved", "")
+        template_data["landUsePlanDateApproved"] = template_data.get("dateApproved", "") or template_data.get(
+            "landUsePlanDateApproved", ""
+        )
 
         template_data["responsibleOfficial"] = template_data["responsibleOfficial"]
         template_data["approvalDate"] = self._get_last_approval_date(template_data["approvers"])

--- a/artifacts.py
+++ b/artifacts.py
@@ -303,9 +303,9 @@ class v1_do_artifacts_connector:
         lupDecisions = template_data.get("landUsePlanDecisionText", "") or template_data.get("lupDecisions", "")
         template_data["lupDecisions"] = lupDecisions.split("\n")
 
-        template_data["landUsePlanDateApproved"] = template_data.get("dateApproved", "") or template_data.get(
+        template_data["landUsePlanDateApproved"] = template_data.get(
             "landUsePlanDateApproved", ""
-        )
+        ) or template_data.get("dateApproved", "")
 
         template_data["responsibleOfficial"] = template_data["responsibleOfficial"]
         template_data["approvalDate"] = self._get_last_approval_date(template_data["approvers"])

--- a/templates/blm-ce.html
+++ b/templates/blm-ce.html
@@ -52,7 +52,7 @@
             <h3>Land Use Plan Conformance:</h3>
             <p>
               Land Use Plan Name: {{ landUsePlanName }}<br />
-              Date Approved: {{ dateApproved }}<br />
+              Date Approved: {{ landUsePlanDateApproved }}<br />
               The proposed action is in conformance with the applicable LUP
               because...
             </p>

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -138,7 +138,7 @@ class TestBLMSpecificFlows:
                 "applicant": "applicant_val",
                 "projectDescription": "projectDescription_val",
                 "landUsePlanName": "landUsePlanName_val",
-                "dateApproved": "dateApproved_val",
+                "landUsePlanDateApproved": "landUsePlanDateApproved_val",
                 "exclusionsText": "Fake exclusions",
                 "lupDecisions": "Fake LUP decisions",
                 "approvers": [


### PR DESCRIPTION
Related to https://github.com/GSA-TTS/pic-blm-cxworks/pull/1005.

After @btylerburton's work in https://github.com/GSA-TTS/pic-blm-cxworks/pull/967 and https://github.com/GSA-TTS/spiffworkflow-connector/pull/79, we can now build a PDF directly from the project page UI (hooray!). This PR and its related pic-blm-cxworks PR fix a couple of mismatches between the data we pass into the connector and the shape of data that the connector expects.